### PR TITLE
Feat: Modal 컴포넌트 루트 바깥으로 띄우기

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,9 @@
 		<meta property="og:type" content="website" />
 	</head>
 	<body>
-		<div id="root"></div>
+		<div id="toast-root"></div>
+		<div id="modal-root"></div>
+		<div id="app-root"></div>
 		<script type="module" src="/src/main.tsx"></script>
 		<!-- <script src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=tm1ukcwtsp&submodules=geocoder" defer /></script>
 		<script src="../thistthat_FE/public/naverCluster.js" defer ></script> -->

--- a/src/components/Modal/UI/Content.tsx
+++ b/src/components/Modal/UI/Content.tsx
@@ -14,25 +14,23 @@ export default function Content({
 	className,
 	...props
 }: ContentProps) {
-	const { isOpen, toggleOpen } = useModal();
+	const { isOpen } = useModal();
 	if (!isOpen) return null;
 
 	return (
 		<LazyMotion features={domAnimation}>
-			<div className="background" onClick={toggleOpen}>
-				<m.div
-					{...props}
-					className={`${styles.container} ${className}`}
-					initial={{ opacity: 0, y: "100%" }}
-					animate={{ opacity: 1, y: 0 }}
-					exit={{ opacity: 0, y: "100%" }}
-					transition={{ duration: 0.3 }}
-					onClick={stopEvent("propagation")}
-				>
-					<div className={styles.element} />
-					{children}
-				</m.div>
-			</div>
+			<m.div
+				{...props}
+				className={`${styles.container} ${className}`}
+				initial={{ opacity: 0, y: "100%" }}
+				animate={{ opacity: 1, y: 0 }}
+				exit={{ opacity: 0, y: "100%" }}
+				transition={{ duration: 0.3 }}
+				onClick={stopEvent("propagation")}
+			>
+				<div className={styles.element} />
+				{children}
+			</m.div>
 		</LazyMotion>
 	);
 }

--- a/src/components/Modal/UI/ModalRoot.tsx
+++ b/src/components/Modal/UI/ModalRoot.tsx
@@ -1,6 +1,7 @@
 import Close from "./Close";
 import Content from "./Content";
 import { ModalContext } from "../hooks/useModal";
+import Overlay from "./Overlay";
 import React from "react";
 import Trigger from "./Trigger";
 import useToggle from "@/hooks/useToggle";
@@ -13,6 +14,7 @@ interface ModalRootProps {
 	children: React.ReactNode;
 }
 
+/** 외부에서 isOpen 상태 받아옴 */
 export default function ModalRoot({
 	isOpen,
 	onOpen,
@@ -26,6 +28,7 @@ export default function ModalRoot({
 	);
 }
 
+/** 내부에서 isOpen 상태 생성 */
 export function ModalWithOpen({ children }: { children: React.ReactNode }) {
 	const { isOpen, onClose, onOpen, toggleOpen } = useToggle();
 
@@ -42,6 +45,7 @@ interface ModalTemplateProps {
 	close: boolean;
 }
 
+/** 외부에서 모든 정보를 받아오는 가이드 */
 export function ModalTemplate({ trigger, content, close }: ModalTemplateProps) {
 	const { isOpen, onClose, onOpen, toggleOpen } = useToggle();
 
@@ -50,8 +54,10 @@ export function ModalTemplate({ trigger, content, close }: ModalTemplateProps) {
 	return (
 		<ModalContext.Provider value={value}>
 			<Trigger>{trigger}</Trigger>
-			<Content>{content}</Content>
-			{close && <Close />}
+			<Overlay>
+				<Content>{content}</Content>
+				{close && <Close />}
+			</Overlay>
 		</ModalContext.Provider>
 	);
 }

--- a/src/components/Modal/UI/Overlay.tsx
+++ b/src/components/Modal/UI/Overlay.tsx
@@ -1,0 +1,20 @@
+import { ModalContext } from "../hooks/useModal";
+import ReactDOM from "react-dom";
+import { useContext } from "react";
+
+interface ModalRootProps {
+	children: React.ReactNode;
+}
+
+export default function Overlay({ children }: ModalRootProps) {
+	const { isOpen, toggleOpen } = useContext(ModalContext);
+
+	if (!isOpen) return null;
+
+	return ReactDOM.createPortal(
+		<div className="background" onClick={toggleOpen}>
+			{children}
+		</div>,
+		document.getElementById("modal-root")!,
+	);
+}

--- a/src/components/Modal/index.stories.tsx
+++ b/src/components/Modal/index.stories.tsx
@@ -22,10 +22,12 @@ const Template = () => {
 				<Modal.Trigger>
 					<button>모달 열기</button>
 				</Modal.Trigger>
-				<Modal.Content>
-					모달입니다.
-					<Modal.Close />
-				</Modal.Content>
+				<Modal.Overlay>
+					<Modal.Content>
+						모달입니다.
+						<Modal.Close />
+					</Modal.Content>
+				</Modal.Overlay>
 			</Modal>
 		</main>
 	);

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,12 +1,14 @@
 import Close from "./UI/Close";
 import Content from "./UI/Content";
 import ModalRoot from "./UI/ModalRoot";
+import Overlay from "./UI/Overlay";
 import Trigger from "./UI/Trigger";
 
 const Modal = Object.assign(ModalRoot, {
 	Trigger,
 	Content,
 	Close,
+	Overlay,
 });
 
 export default Modal;

--- a/src/components/Modal/styles/Content.module.scss
+++ b/src/components/Modal/styles/Content.module.scss
@@ -4,8 +4,6 @@
 .container {
 	background-color: $white;
 	position: fixed;
-	right: 0;
-	left: 0;
 	bottom: 0;
 	border-top-left-radius: 20px;
 	border-top-right-radius: 20px;
@@ -18,6 +16,8 @@
 		max-width: 480px;
 		position: absolute;
 		bottom: 0;
+		left: 50%;
+		transform: translateX(-50%) !important;
 	}
 	.element {
 		height: 7px;

--- a/src/components/PopupModal/index.tsx
+++ b/src/components/PopupModal/index.tsx
@@ -1,3 +1,4 @@
+import ReactDOM from "react-dom";
 import styles from "./index.module.scss";
 
 interface PopupModalProps {
@@ -15,7 +16,7 @@ const PopupModal = ({
 	onClick,
 	onClose,
 }: PopupModalProps) => {
-	return (
+	return ReactDOM.createPortal(
 		<div className="background" onClick={onClose}>
 			<div className={styles.container}>
 				<div className={styles["content-container"]}>
@@ -33,7 +34,8 @@ const PopupModal = ({
 					</button>
 				</div>
 			</div>
-		</div>
+		</div>,
+		document.getElementById("modal-root")!,
 	);
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import React, { Suspense } from "react";
 import App from "./App.tsx";
 import Error from "@pages/feedback/UI/Error.tsx";
 import { ErrorBoundary } from "react-error-boundary";
+import JustReactDOM from "react-dom";
 import Loading from "./pages/feedback/Loading.tsx";
 import ReactDOM from "react-dom/client";
 import { ToastContainer } from "react-toastify";
@@ -43,13 +44,20 @@ export const queryClient = new QueryClient({
 	// }),
 });
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const Toast = () => {
+	return JustReactDOM.createPortal(
+		<ToastContainer />,
+		document.getElementById("toast-root")!,
+	);
+};
+
+ReactDOM.createRoot(document.getElementById("app-root")!).render(
 	<React.StrictMode>
 		<ErrorBoundary FallbackComponent={Error}>
 			<Suspense fallback={<Loading isFullLoading />}>
 				<QueryClientProvider client={queryClient}>
 					<App />
-					<ToastContainer />
+					<Toast />
 					{/* <ReactQueryDevtools initialIsOpen={false} position="bottom" /> */}
 				</QueryClientProvider>
 			</Suspense>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,10 +10,10 @@ import React, { Suspense } from "react";
 import App from "./App.tsx";
 import Error from "@pages/feedback/UI/Error.tsx";
 import { ErrorBoundary } from "react-error-boundary";
-import JustReactDOM from "react-dom";
 import Loading from "./pages/feedback/Loading.tsx";
 import ReactDOM from "react-dom/client";
 import { ToastContainer } from "react-toastify";
+import { createPortal } from "react-dom";
 import { showToast } from "./utils/ToastConfig.ts";
 
 // import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
@@ -45,7 +45,7 @@ export const queryClient = new QueryClient({
 });
 
 const Toast = () => {
-	return JustReactDOM.createPortal(
+	return createPortal(
 		<ToastContainer />,
 		document.getElementById("toast-root")!,
 	);

--- a/src/pages/detail/UI/review/ReviewBoardItem.tsx
+++ b/src/pages/detail/UI/review/ReviewBoardItem.tsx
@@ -89,14 +89,16 @@ export default function ReviewBoardItem({
 						</div>
 					</div>
 				</Modal.Trigger>
-				<Modal.Content>
-					<ReviewDetailModal
-						reviewId={reviewId}
-						handleOpenConfirmDelete={() => {
-							setIsOpenConfirmDelete(true);
-						}}
-					/>
-				</Modal.Content>
+				<Modal.Overlay>
+					<Modal.Content>
+						<ReviewDetailModal
+							reviewId={reviewId}
+							handleOpenConfirmDelete={() => {
+								setIsOpenConfirmDelete(true);
+							}}
+						/>
+					</Modal.Content>
+				</Modal.Overlay>
 			</Modal>
 			{isOpenConfirmDelete && (
 				<PopupModal

--- a/src/pages/detail/UI/review/ReviewDetailModal.tsx
+++ b/src/pages/detail/UI/review/ReviewDetailModal.tsx
@@ -57,9 +57,11 @@ export default function ReviewDetailModal({
 				toggleOpen={toggleOpen}
 				onOpen={onOpen}
 			>
-				<Modal.Content>
-					<ReviewEditModal reviewId={reviewId} onClose={onClose} />
-				</Modal.Content>
+				<Modal.Overlay>
+					<Modal.Content>
+						<ReviewEditModal reviewId={reviewId} onClose={onClose} />
+					</Modal.Content>
+				</Modal.Overlay>
 			</Modal>
 			<article className={styles.container}>
 				<h2>{title}</h2>

--- a/src/pages/detail/UI/review/ReviewPostModal.tsx
+++ b/src/pages/detail/UI/review/ReviewPostModal.tsx
@@ -29,13 +29,7 @@ export default function ReviewPostModal() {
 
 	const medicineId = useGetIdByLocation();
 
-	const {
-		register,
-		handleSubmit,
-		setValue,
-		formState: { errors },
-		control,
-	} = useForm({
+	const { register, handleSubmit, setValue, control } = useForm({
 		mode: "onSubmit",
 		resolver: yupResolver(medicineReviewPostValidation),
 	});
@@ -60,7 +54,6 @@ export default function ReviewPostModal() {
 		setImageFiles(imgs);
 	};
 
-	console.log(errors);
 	const onSubmit = ({
 		title,
 		tagList,
@@ -99,33 +92,35 @@ export default function ReviewPostModal() {
 			<Modal.Trigger>
 				<button className={styles.button}>후기 작성하기</button>
 			</Modal.Trigger>
-			<Modal.Content>
-				<ControlForm onSubmit={handleSubmit(onSubmit)}>
-					<ControlForm.Input
-						title="리뷰 제목"
-						placeholder="리뷰 제목을 입력해주세요"
-						{...register("title")}
-					/>
-					<ControlForm.StarRating
-						star={star}
-						onClick={(rating: number) => setValue("star", rating)}
-					/>
-					<ControlForm.TagBoard
-						title="태그 선택"
-						tags={tags ?? []}
-						selectedTags={selectedTags}
-						onTagClick={(selectedTag) => setValue("tagList", selectedTag)}
-						{...register("tagList")}
-					/>
-					<ControlForm.ImgsInput addImgFile={addImgFile} />
-					<ControlForm.Textarea
-						title="후기 작성"
-						placeholder="리뷰를 입력해주세요(최소 50자 이상)"
-						{...register("content")}
-					/>
-					<ControlForm.Button text="후기 작성완료" variant="dark" />
-				</ControlForm>
-			</Modal.Content>
+			<Modal.Overlay>
+				<Modal.Content>
+					<ControlForm onSubmit={handleSubmit(onSubmit)}>
+						<ControlForm.Input
+							title="리뷰 제목"
+							placeholder="리뷰 제목을 입력해주세요"
+							{...register("title")}
+						/>
+						<ControlForm.StarRating
+							star={star}
+							onClick={(rating: number) => setValue("star", rating)}
+						/>
+						<ControlForm.TagBoard
+							title="태그 선택"
+							tags={tags ?? []}
+							selectedTags={selectedTags}
+							onTagClick={(selectedTag) => setValue("tagList", selectedTag)}
+							{...register("tagList")}
+						/>
+						<ControlForm.ImgsInput addImgFile={addImgFile} />
+						<ControlForm.Textarea
+							title="후기 작성"
+							placeholder="리뷰를 입력해주세요(최소 50자 이상)"
+							{...register("content")}
+						/>
+						<ControlForm.Button text="후기 작성완료" variant="dark" />
+					</ControlForm>
+				</Modal.Content>
+			</Modal.Overlay>
 		</Modal>
 	);
 }

--- a/src/pages/detail/index.tsx
+++ b/src/pages/detail/index.tsx
@@ -53,34 +53,32 @@ export default function MedicineDetail() {
 	};
 
 	return (
-		<>
-			<section className={styles.container}>
-				<MedicineCard
-					image={image}
-					name={name}
-					isHeart={isHeart}
-					isBookMark={isBookMark}
-					reviewCount={reviewCount}
-					brand={brand}
-					hashtags={hashtags.slice(0, 2)}
-					grade={grade}
-					heartCount={heartCount}
-				/>
-				<div className={styles.board}>
-					<TapBar taps={TAPS} onClick={handleTapClick} />
-					{currentTapValue === TAPS_QUERIES.REVIEW && (
-						<ReviewBoard medicineId={medicineId} />
-					)}
-					{(currentTapValue === TAPS_QUERIES.INFO ||
-						currentTapValue === null) && (
-						<InfoBoard
-							howToEat={howToEat}
-							ingredient={ingredient}
-							describe={describe}
-						/>
-					)}
-				</div>
-			</section>
-		</>
+		<section className={styles.container}>
+			<MedicineCard
+				image={image}
+				name={name}
+				isHeart={isHeart}
+				isBookMark={isBookMark}
+				reviewCount={reviewCount}
+				brand={brand}
+				hashtags={hashtags.slice(0, 2)}
+				grade={grade}
+				heartCount={heartCount}
+			/>
+			<div className={styles.board}>
+				<TapBar taps={TAPS} onClick={handleTapClick} />
+				{currentTapValue === TAPS_QUERIES.REVIEW && (
+					<ReviewBoard medicineId={medicineId} />
+				)}
+				{(currentTapValue === TAPS_QUERIES.INFO ||
+					currentTapValue === null) && (
+					<InfoBoard
+						howToEat={howToEat}
+						ingredient={ingredient}
+						describe={describe}
+					/>
+				)}
+			</div>
+		</section>
 	);
 }

--- a/src/pages/signup/UI/MailVerifyModal.tsx
+++ b/src/pages/signup/UI/MailVerifyModal.tsx
@@ -1,18 +1,20 @@
 import * as yup from "yup";
-import { useMutation } from "@tanstack/react-query";
-import Modal from "@/components/Modal";
-import postMailVerify from "@/api/user/postMailVerify";
-import { toast } from "react-toastify";
-import postSignUp from "@/api/user/postSignUp";
-import { useNavigate } from "react-router-dom";
-import { ControlForm } from "@/components/ControlForm";
-import { SignUpFormType } from "../utils/signupValidation";
+
 import { useForm, useWatch } from "react-hook-form";
+
+import { ControlForm } from "@/components/ControlForm";
 import { ErrorMessage } from "@hookform/error-message";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { useState } from "react";
-import styles from "../styles/SignUp.module.scss";
+import Modal from "@/components/Modal";
+import { SignUpFormType } from "../utils/signupValidation";
 import Timer from "../utils/Timer";
+import postMailVerify from "@/api/user/postMailVerify";
+import postSignUp from "@/api/user/postSignUp";
+import styles from "../styles/SignUp.module.scss";
+import { toast } from "react-toastify";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import { yupResolver } from "@hookform/resolvers/yup";
 
 export default function MailVerifyModal({
 	isOpen,
@@ -111,48 +113,50 @@ export default function MailVerifyModal({
 			toggleOpen={toggleOpen}
 			onOpen={onOpen}
 		>
-			<Modal.Content>
-				<ControlForm onSubmit={handleSubmit(onSubmit)}>
-					<ControlForm.Input
-						title="이메일"
-						placeholder="이메일을 입력해주세요."
-						value={signUpData.username}
-						readOnly
-					/>
-					<div className={styles.checkWrap}>
-						<Timer
-							count={timerCount}
-							setCount={setTimerCount}
-							className={styles.count}
+			<Modal.Overlay>
+				<Modal.Content>
+					<ControlForm onSubmit={handleSubmit(onSubmit)}>
+						<ControlForm.Input
+							title="이메일"
+							placeholder="이메일을 입력해주세요."
+							value={signUpData.username}
+							readOnly
 						/>
-						<div className={styles.checkFlex}>
-							<ControlForm.Input
-								title="이메일 인증번호"
-								placeholder="인증번호를 입력해주세요."
-								{...register("verify")}
-								className={errors.verify ? styles.error : ""}
+						<div className={styles.checkWrap}>
+							<Timer
+								count={timerCount}
+								setCount={setTimerCount}
+								className={styles.count}
 							/>
-							<ControlForm.Button
-								onClick={handleVerify}
-								text="인증번호 확인"
-								type="button"
-								variant="dark"
+							<div className={styles.checkFlex}>
+								<ControlForm.Input
+									title="이메일 인증번호"
+									placeholder="인증번호를 입력해주세요."
+									{...register("verify")}
+									className={errors.verify ? styles.error : ""}
+								/>
+								<ControlForm.Button
+									onClick={handleVerify}
+									text="인증번호 확인"
+									type="button"
+									variant="dark"
+								/>
+							</div>
+							<ErrorMessage
+								errors={errors}
+								name="verify"
+								render={({ message }) => <p>{message}</p>}
 							/>
 						</div>
-						<ErrorMessage
-							errors={errors}
-							name="verify"
-							render={({ message }) => <p>{message}</p>}
+						<ControlForm.Button
+							text="가입하기"
+							type="submit"
+							variant="dark"
+							className={styles.buttonStyle}
 						/>
-					</div>
-					<ControlForm.Button
-						text="가입하기"
-						type="submit"
-						variant="dark"
-						className={styles.buttonStyle}
-					/>
-				</ControlForm>
-			</Modal.Content>
+					</ControlForm>
+				</Modal.Content>
+			</Modal.Overlay>
 		</Modal>
 	);
 }

--- a/src/pages/userinfo/UI/Review/ReviewDisplay.tsx
+++ b/src/pages/userinfo/UI/Review/ReviewDisplay.tsx
@@ -54,14 +54,16 @@ const ReviewDisplay = ({ reviews }: ReviewDisplayProps) => {
 					))}
 				</div>
 			</Modal.Trigger>
-			{reviews.map((review) => (
-				<Modal.Content>
-					<ReviewDetailModal
-						handleOpenConfirmDelete={onClose}
-						reviewId={review.id}
-					/>
-				</Modal.Content>
-			))}
+			<Modal.Overlay>
+				{reviews.map((review) => (
+					<Modal.Content>
+						<ReviewDetailModal
+							handleOpenConfirmDelete={onClose}
+							reviewId={review.id}
+						/>
+					</Modal.Content>
+				))}
+			</Modal.Overlay>
 		</Modal>
 	);
 };

--- a/src/pages/userinfo/UI/Supplement/SupplementHistory.tsx
+++ b/src/pages/userinfo/UI/Supplement/SupplementHistory.tsx
@@ -127,15 +127,16 @@ const SupplementHistory = () => {
 							))}
 					</div>
 				</Modal.Trigger>
-
-				<Modal.Content>
-					{selectedSupplement?.medicineName && (
-						<SupplementModal
-							itemId={selectedSupplement.id}
-							onClose={onCloseSupplement}
-						/>
-					)}
-				</Modal.Content>
+				<Modal.Overlay>
+					<Modal.Content>
+						{selectedSupplement?.medicineName && (
+							<SupplementModal
+								itemId={selectedSupplement.id}
+								onClose={onCloseSupplement}
+							/>
+						)}
+					</Modal.Content>
+				</Modal.Overlay>
 			</Modal>
 
 			<Modal
@@ -147,12 +148,14 @@ const SupplementHistory = () => {
 				<Modal.Trigger>
 					<CommonCardBox form={cardForm} />
 				</Modal.Trigger>
-				<Modal.Content>
-					<SupplementAddForm
-						formInitialValues={noSupplementData}
-						onClose={onCloseEditSupplement}
-					/>
-				</Modal.Content>
+				<Modal.Overlay>
+					<Modal.Content>
+						<SupplementAddForm
+							formInitialValues={noSupplementData}
+							onClose={onCloseEditSupplement}
+						/>
+					</Modal.Content>
+				</Modal.Overlay>
 			</Modal>
 
 			<div ref={ref} style={{ height: 20 }}>

--- a/src/pages/userinfo/UI/UserInfoBox.tsx
+++ b/src/pages/userinfo/UI/UserInfoBox.tsx
@@ -58,16 +58,18 @@ const UserInfoBox = ({ userData }: UserInfoBoxProps) => {
 							<Modal.Trigger>
 								<div className={style.editprofile}>프로필 수정하기</div>
 							</Modal.Trigger>
-							<Modal.Content>
-								<div
-									className={`${style.profileEditModal} ${modalStyle.container} `}
-								>
-									<UserInfoEdit
-										onClose={onCloseEditUserData}
-										userData={userData}
-									/>
-								</div>
-							</Modal.Content>
+							<Modal.Overlay>
+								<Modal.Content>
+									<div
+										className={`${style.profileEditModal} ${modalStyle.container} `}
+									>
+										<UserInfoEdit
+											onClose={onCloseEditUserData}
+											userData={userData}
+										/>
+									</div>
+								</Modal.Content>
+							</Modal.Overlay>
 						</Modal>
 					</div>
 				</div>


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- ReactDOM.createPortal을 사용하여 컴포넌트 루트 바깥으로 Modal을 위치 변경했습니다!
- 변경 사항은 Modal 사용한 전체에 적용했습니당
- Toastify도 컴포넌트 루트에 형제노드로 있으면 좋을 것 같아서 main.tsx에서 한번 띄워서 위치시켰습니다
- https://legacy.reactjs.org/docs/portals.html
- https://a-honey.tistory.com/60

<br/>

### 📷 스크린 샷

![image](https://github.com/iyakjeoyak/iyakjeoyak-FE/assets/75254185/4150ada7-1ed5-4690-b707-25aa6acfddd9)

<br/>
